### PR TITLE
fix(stock_split): support multiple successive splits.

### DIFF
--- a/autobean/stock_split/plugin.py
+++ b/autobean/stock_split/plugin.py
@@ -67,7 +67,7 @@ def plugin(entries: list[Directive], options_map: dict[str, Any]) -> tuple[list[
 
         multiplier, commodity = entry.values[0].value
         postings = realizer.get_split_postings(commodity, multiplier)
-        results.append(Transaction(
+        txn = Transaction(
             date=entry.date,
             flag='*',
             payee=None,
@@ -76,6 +76,8 @@ def plugin(entries: list[Directive], options_map: dict[str, Any]) -> tuple[list[
             links=set(),
             postings=list(postings),
             meta=entry.meta,
-        ))
+        )
+        realizer.realize_transaction(txn)
+        results.append(txn)
 
     return results, logger.errors

--- a/autobean/stock_split/plugin_test.py
+++ b/autobean/stock_split/plugin_test.py
@@ -34,6 +34,26 @@ _FOO_TEXT = textwrap.dedent('''
 
     2000-05-02 balance Assets:Foo 2000.00 STOCK
     2000-05-02 balance Assets:Bar 1000.00 STOCK
+
+    2000-05-03 *
+        Income:Foo   -1 USD
+        Assets:Bar   1 STOCK.B {{1 USD}}
+
+    2000-05-04 balance Assets:Foo 2000.00 STOCK
+    2000-05-04 balance Assets:Bar 1000.00 STOCK
+    2000-05-04 balance Assets:Bar 1 STOCK.B
+
+    2000-05-05 custom "autobean.stock_split" 2 STOCK
+
+    2000-05-06 balance Assets:Foo 4000.00 STOCK
+    2000-05-06 balance Assets:Bar 2000.00 STOCK
+    2000-05-06 balance Assets:Bar 1 STOCK.B
+
+    2000-05-07 custom "autobean.stock_split" 2 STOCK.B
+
+    2000-05-08 balance Assets:Foo 4000.00 STOCK
+    2000-05-08 balance Assets:Bar 2000.00 STOCK
+    2000-05-08 balance Assets:Bar 2 STOCK.B
 ''')
 
 
@@ -53,7 +73,7 @@ def load(text: str) -> tuple[list[Directive], list[Any]]:
 def test_ok() -> None:
     entries, errors = load(_FOO_TEXT)
     assert not errors
-    txn = entries[-3]
+    txn = entries[-15]
     assert isinstance(txn, Transaction)
     assert txn.date == datetime.date(2000, 5, 1)
     assert txn.narration == 'STOCK split 10:1'
@@ -69,6 +89,33 @@ def test_ok() -> None:
  Assets:Foo 1000.00 STOCK {0.6 USD, 2000-03-01}\
 '''
 
+    txn = entries[-8]
+    assert isinstance(txn, Transaction)
+    assert txn.date == datetime.date(2000, 5, 5)
+    assert txn.narration == 'STOCK split 2:1'
+    f = io.StringIO()
+    printer.print_entry(txn, file=f)
+    text = '\n'.join(sorted(filter(None, re.sub(r' +', ' ', f.getvalue()).split('\n')[1:])))
+    assert text == '''\
+ Assets:Bar -1000.00 STOCK {0.6 USD, 2000-04-01}
+ Assets:Bar 2000.00 STOCK {0.3 USD, 2000-04-01}
+ Assets:Foo -1000.00 STOCK {0.5 USD, 2000-02-01}
+ Assets:Foo -1000.00 STOCK {0.6 USD, 2000-03-01}
+ Assets:Foo 2000.00 STOCK {0.25 USD, 2000-02-01}
+ Assets:Foo 2000.00 STOCK {0.3 USD, 2000-03-01}\
+'''
+
+    txn = entries[-4]
+    assert isinstance(txn, Transaction)
+    assert txn.date == datetime.date(2000, 5, 7)
+    assert txn.narration == 'STOCK.B split 2:1'
+    f = io.StringIO()
+    printer.print_entry(txn, file=f)
+    text = '\n'.join(sorted(filter(None, re.sub(r' +', ' ', f.getvalue()).split('\n')[1:])))
+    assert text == '''\
+ Assets:Bar -1 STOCK.B {1 USD, 2000-05-03}
+ Assets:Bar 2 STOCK.B {0.5 USD, 2000-05-03}\
+'''
 
 @pytest.mark.parametrize('text', [
     '2000-05-01 custom "autobean.stock_split" STOCK',


### PR DESCRIPTION
`stock_split` currently produces incorrect results for multiple successive splits. Each splits fails to take the prior splits into account, and instead operates on the un-split balance. For example, an account with 1 STOCK that undergoes two 2:1 splits should end up with 4 STOCK, but currently will end up with 3 STOCK.

This PR fixes the bug by booking each split transaction as it is generated.