### PR TITLE
fix(truelayer): log and raise http errors

### DIFF
--- a/autobean/truelayer/importer.py
+++ b/autobean/truelayer/importer.py
@@ -99,6 +99,9 @@ class _Extractor:
             'cards': 'https://api.truelayer.com/data/v1/cards',
         }
         r = requests.get(url[type_], headers=self._auth_headers)
+        if not r.ok:
+            logging.error('Error fetching accounts: %s', r.text)
+            r.raise_for_status()
         accounts = r.json().get('results', [])
         config_accounts = self._config.data.setdefault(type_, {})
         for account in accounts:
@@ -146,6 +149,9 @@ class _Extractor:
                 'to': format_iso_datetime(time.time()),
             }
         )
+        if not r.ok:
+            logging.error('Error fetching transactions: %s', r.text)
+            r.raise_for_status()
         txns = r.json().get('results', [])
         logging.info(
             f'Fetched {len(txns)} {log_transaction} for account '
@@ -164,6 +170,9 @@ class _Extractor:
         logging.info(
             f'Fetching balance for account {account["name"]} ({account_id}).')
         r = requests.get(url[type_], headers=self._auth_headers)
+        if not r.ok:
+            logging.error('Error fetching balance: %s', r.text)
+            r.raise_for_status()
         balances = r.json().get('results', [])
         logging.info(
             f'Fetched {len(balances)} balance entries for account '


### PR DESCRIPTION
I noticed a couple of my accounts failing to get (non-pending) transactions any more, having worked previously. Looks like there was an error triggered when requesting more than 90 days of transaction, but the error was being hidden.

```
ERROR:root:Error fetching: {"error_description":"Access denied","error":"access_denied","error_details":{"provider_details":"Client application error: NO-BODY"}}
ERROR:root:Importer autobean.truelayer.extract() raised an unexpected error: 403 Client Error: Forbidden for url: ...
Traceback (most recent call last):
```

Added logging and raise the error to make it obvious there's a problem.

(I wonder if `from` should be updated to request only last 90 days - on two banks if I request more I see this 403)