### PR TITLE
xcheck: ignore balance assertions from non-matching accounts

### DIFF
--- a/autobean/xcheck/plugin.py
+++ b/autobean/xcheck/plugin.py
@@ -69,7 +69,7 @@ class CrossCheckPlugin(plugin_lib.BasePlugin):
             ))
         self._includes.add(path)
         for stmt_entry in stmt_entries:
-            if isinstance(stmt_entry, Balance):
+            if isinstance(stmt_entry, Balance) and (not accounts or stmt_entry.account in accounts):
                 yield stmt_entry
         yield entry
 


### PR DESCRIPTION
When using the xcheck plugin, currently, all balance assertions are copied over, even if a list of accounts is specified. This leads to errors if not all accounts used in balance assertions exist in both files.

This PR changes that behavior and only copies over balance assertions that match one of the specified accounts (in case accounts are specified)