### PR TITLE
fix(truelayer): Skip unsupported account types

### DIFF
--- a/autobean/truelayer/importer.py
+++ b/autobean/truelayer/importer.py
@@ -183,6 +183,9 @@ class _Extractor:
     def _fetch_all_transactions(self) -> list[Directive]:
         entries: list[Directive] = []
         for type_ in ACCOUNT_TYPES:
+            if not type_ in self._config.data:
+                continue
+
             for account_id, account in self._config.data[type_].items():
                 if not account['enabled']:
                     continue


### PR DESCRIPTION
Some providers (e.g. barclaycard) do not support both "accounts" and "cards". If the truelayer importer comes across such a provider, it will fail to fetch the unsupported account type, and omit that from the config

If the key is omitted from the config, we'll try to read from an invalid key when we later look for all transactions